### PR TITLE
Updated WiringPi and libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "wiringpi"
 version = "0.1.2"
 authors = ["Erik Hedvall <hello@erikhedvall.nu>"]
@@ -21,4 +20,4 @@ nightly = []
 noclib = []
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"


### PR DESCRIPTION
I updated WiringPi and libc, but I'm still getting these warnings in the latest stable Rust branch. It seems it will be an issue in the future:

```
src/lib.rs:176:9: 176:38 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:176         fn pwm_pin() -> PwmPin<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:176:9: 176:38 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:176:9: 176:38 note: `Self` does not have a constant size known at compile-time
src/lib.rs:176:9: 176:38 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:176         fn pwm_pin() -> PwmPin<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:176:9: 176:38 note: required by `pin::PwmPin`
src/lib.rs:180:9: 180:42 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:180         fn clock_pin() -> ClockPin<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:180:9: 180:42 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:180:9: 180:42 note: `Self` does not have a constant size known at compile-time
src/lib.rs:180:9: 180:42 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:180         fn clock_pin() -> ClockPin<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:180:9: 180:42 note: required by `pin::ClockPin`
```
