### PR TITLE
Add support for Orange PI via WiringOP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "wiringPi"]
 	path = wiringPi
 	url = git://git.drogon.net/wiringPi
+[submodule "WiringOP"]
+	path = WiringOP
+	url = https://github.com/zhaolei/WiringOP.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,8 @@ nightly = []
 #Useful when building documentation
 noclib = []
 
+#Build patched version or wiringpi for Orange PI
+orangepi = []
+
 [dependencies]
 libc = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ wiringop:
 	rm -f $(OUT_DIR)/libwiringpi.a
 	cp WiringOP/wiringPi/libwiringPi.a $(OUT_DIR)/libwiringpi.a
 
-.PHONY: wiringpi
+.PHONY: wiringpi wiringop

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,11 @@ wiringpi:
 	$(MAKE) -C wiringPi/wiringPi static CC=arm-linux-gnueabihf-gcc DEBUG=-O2
 	rm -f $(OUT_DIR)/libwiringpi.a
 	cp wiringPi/wiringPi/libwiringPi.a $(OUT_DIR)/libwiringpi.a
+wiringop:
+	@echo >&2 $(CFLAGS)
+	$(MAKE) -C WiringOP/wiringPi clean
+	$(MAKE) -C WiringOP/wiringPi static CC=arm-linux-gnueabihf-gcc DEBUG=-O2
+	rm -f $(OUT_DIR)/libwiringpi.a
+	cp WiringOP/wiringPi/libwiringPi.a $(OUT_DIR)/libwiringpi.a
 
 .PHONY: wiringpi

--- a/README.md
+++ b/README.md
@@ -54,3 +54,14 @@ This project can be cross compiled using Cargo.
 [Follow these instructions](https://github.com/Ogeon/rust-on-raspberry-pi)
 And use `./cross64 build` or `./cross32 build`, depending on your system,
 to check if everything builds as expected.
+
+##Orange Pi support
+
+`rust-wiringpi` can also wrap the WiringOP library for the Orange Pi SBC boards.
+This can be enabled with the `orangepi` feature:
+
+```
+[dependencies.wiringpi]
+verson = "0.1"
+features = ["orangepi"]
+```

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,15 @@
 use std::process::Command;
 use std::env;
 
+#[cfg(not(feature = "orangepi"))]
+const TARGET: &'static str = "wiringpi";
+#[cfg(feature = "orangepi")]
+const TARGET: &'static str = "wiringop";
+
 fn main() {
     if !cfg!(feature = "noclib") {
         let out_dir = env::var("OUT_DIR").unwrap();
-        match Command::new("make").arg("-e").status() {
+        match Command::new("make").arg("-e").arg(TARGET).status() {
             Ok(status) if !status.success() => panic!("failed to build wiringPi C library (exit code {:?})", status.code()),
             Err(e) => panic!("failed to build wiringPi C library: {}", e),
             _ => {}


### PR DESCRIPTION
Besides Raspberry PI I also have an Orange PI board, which requires patched version of WiringPI. Feel free to merge if you find this ok. Thanks!
