### PR TITLE
Use multirust to perform build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,26 @@
-language: rust
+language: generic
 os:
   - linux
+install:
+  - export PATH="$PATH:$HOME/multirust/bin"
+  - git clone https://github.com/brson/multirust
+  - pushd multirust
+  - ./build.sh
+  - ./install.sh --prefix=~/multirust
+  - multirust default beta
+  - multirust add-target beta arm-unknown-linux-gnueabihf
+  - rustc -V
+  - cargo -V
+  - popd
+  - mkdir ~/.cargo
+  - cp scripts/config ~/.cargo/config
+  - git clone https://github.com/raspberrypi/tools.git ~/pi-tools
+  - cp scripts/gcc-sysroot ~/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
+  - chmod +x ~/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot
 script:
+  - ./cross64 "build -v"
+  - ./cross64 "build -v --example flashing_lights"
+  - ./cross64 "build -v --features orangepi"
+  - ./cross64 "build -v --features orangepi --example flashing_lights"
   - cargo doc --features noclib
 after_success: curl https://raw.githubusercontent.com/ogeon/travis-doc-upload/master/travis-doc-upload.sh | sh

--- a/cross32
+++ b/cross32
@@ -1,17 +1,12 @@
 #!/bin/sh
 
-rust=$2
-tools=$3
-: ${rust:="$HOME/pi-rust"}
+tools=$2
 : ${tools:="$HOME/pi-tools"}
 
 export SYSROOT="$tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot"
 
-#Point rustc to the standard libraries
-export LD_LIBRARY_PATH="$rust/lib":$LD_LIBRARY_PATH
-
 #Include the cross copilation binaries
-export PATH="$rust/bin":"$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin":$PATH
+export PATH="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin":$PATH
 
 if [ "$1" != "doc" ]
 then

--- a/cross64
+++ b/cross64
@@ -1,17 +1,12 @@
 #!/bin/sh
 
-rust=$2
-tools=$3
-: ${rust:="$HOME/pi-rust"}
+tools=$2
 : ${tools:="$HOME/pi-tools"}
 
 export SYSROOT="$tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot"
 
-#Point rustc to the standard libraries
-export LD_LIBRARY_PATH="$rust/lib":$LD_LIBRARY_PATH
-
 #Include the cross copilation binaries
-export PATH="$rust/bin":"$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin":$PATH
+export PATH="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin":$PATH
 
 if [ "$1" != "doc" ]
 then

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,3 @@
+[target.arm-unknown-linux-gnueabihf]
+ar = "arm-linux-gnueabihf-ar"
+linker = "gcc-sysroot"

--- a/scripts/gcc-sysroot
+++ b/scripts/gcc-sysroot
@@ -1,0 +1,2 @@
+#!/bin/bash
+arm-linux-gnueabihf-gcc --sysroot=$HOME/pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot "$@"


### PR DESCRIPTION
This uses the `add-target` feature to download the ARM std libraries and runs cross compilation tests on Travis. It's currently using the `beta` channel until Rust 1.8 is out.
