### PR TITLE
Updated to use rustup.rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,42 @@
 language: generic
+dist: trusty
 os:
   - linux
+addons:
+  apt:
+    packages:
+      - gcc-arm-linux-gnueabihf
+
+# Build for all chains since Rust 1.8.0 (not available for prior versions)
+env:
+  - RUST=nightly
+  - RUST=beta
+  - RUST=stable
+  - RUST=1.8.0
+
+# Install rust
 install:
-  - export PATH="$PATH:$HOME/multirust/bin"
-  - git clone https://github.com/brson/multirust
-  - pushd multirust
-  - ./build.sh
-  - ./install.sh --prefix=~/multirust
-  - multirust default beta
-  - multirust add-target beta arm-unknown-linux-gnueabihf
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y
+  - export PATH="$HOME/.cargo/bin:$PATH"
+  - rustup toolchain install $RUST
+  - rustup default $RUST
+  - rustup target add arm-unknown-linux-gnueabihf
   - rustc -V
   - cargo -V
-  - popd
-  - mkdir ~/.cargo
   - cp scripts/config ~/.cargo/config
   - git clone https://github.com/raspberrypi/tools.git ~/pi-tools
   - cp scripts/gcc-sysroot ~/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
   - chmod +x ~/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot
+  - export SYSROOT="$HOME/pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot"
+  - export PATH="$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:$PATH"
+  - export CC="$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot"
+  - export AR="$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-ar"
+
 script:
-  - ./cross64 "build -v"
-  - ./cross64 "build -v --example flashing_lights"
-  - ./cross64 "build -v --features orangepi"
-  - ./cross64 "build -v --features orangepi --example flashing_lights"
-  - cargo doc --features noclib
+  - cargo build -v --target=arm-unknown-linux-gnueabihf
+  - cargo build -v --target=arm-unknown-linux-gnueabihf --features orangepi
+  - cargo build -v --target=arm-unknown-linux-gnueabihf --example flashing_lights
+  - cargo build -v --target=arm-unknown-linux-gnueabihf --features orangepi --example flashing_lights
+  - cargo doc -v --target=arm-unknown-linux-gnueabihf --features noclib
+
 after_success: curl https://raw.githubusercontent.com/ogeon/travis-doc-upload/master/travis-doc-upload.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: generic
-dist: trusty
 os:
   - linux
-addons:
-  apt:
-    packages:
-      - gcc-arm-linux-gnueabihf
 
 # Build for all chains since Rust 1.8.0 (not available for prior versions)
 env:
@@ -27,16 +22,12 @@ install:
   - git clone https://github.com/raspberrypi/tools.git ~/pi-tools
   - cp scripts/gcc-sysroot ~/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
   - chmod +x ~/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot
-  - export SYSROOT="$HOME/pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot"
-  - export PATH="$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:$PATH"
-  - export CC="$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot"
-  - export AR="$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-ar"
 
 script:
-  - cargo build -v --target=arm-unknown-linux-gnueabihf
-  - cargo build -v --target=arm-unknown-linux-gnueabihf --features orangepi
-  - cargo build -v --target=arm-unknown-linux-gnueabihf --example flashing_lights
-  - cargo build -v --target=arm-unknown-linux-gnueabihf --features orangepi --example flashing_lights
-  - cargo doc -v --target=arm-unknown-linux-gnueabihf --features noclib
+  - ./cross64 "build -v"
+  - ./cross64 "build -v --features orangepi"
+  - ./cross64 "build -v --example flashing_lights"
+  - ./cross64 "build -v --features orangepi --example flashing_lights"
+  - ./cross64 "doc -v"
 
 after_success: curl https://raw.githubusercontent.com/ogeon/travis-doc-upload/master/travis-doc-upload.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: generic
 os:
   - linux
+dist: trusty
 
 # Build for all chains since Rust 1.8.0 (not available for prior versions)
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ license = "MIT"
 #Opt in to Rust-nightly features
 nightly = []
 
-#Don't build wiringPi C library.
-#Useful when building documentation
-noclib = []
-
 #Build patched version or wiringpi for Orange PI
 orangepi = []
 

--- a/build.rs
+++ b/build.rs
@@ -7,13 +7,11 @@ const TARGET: &'static str = "wiringpi";
 const TARGET: &'static str = "wiringop";
 
 fn main() {
-    if !cfg!(feature = "noclib") {
-        let out_dir = env::var("OUT_DIR").unwrap();
-        match Command::new("make").arg("-e").arg(TARGET).status() {
-            Ok(status) if !status.success() => panic!("failed to build wiringPi C library (exit code {:?})", status.code()),
-            Err(e) => panic!("failed to build wiringPi C library: {}", e),
-            _ => {}
-        }
-        println!("cargo:rustc-flags=-L native={} -l static=wiringpi", out_dir);
+    let out_dir = env::var("OUT_DIR").unwrap();
+    match Command::new("make").arg("-e").arg(TARGET).status() {
+        Ok(status) if !status.success() => panic!("failed to build wiringPi C library (exit code {:?})", status.code()),
+        Err(e) => panic!("failed to build wiringPi C library: {}", e),
+        _ => {}
     }
+    println!("cargo:rustc-flags=-L native={} -l static=wiringpi", out_dir);
 }

--- a/cross32
+++ b/cross32
@@ -8,15 +8,12 @@ export SYSROOT="$tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708ha
 #Include the cross copilation binaries
 export PATH="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin":$PATH
 
-if [ "$1" != "doc" ]
-then
-	#Set up our tools for anyting using these variables
-	export CC="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/gcc-sysroot"
-	export AR="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-ar"
+#Set up our tools for anyting using these variables
+export CC="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/gcc-sysroot"
+export AR="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-ar"
 
-	#Set target triple
-	flags="--target=arm-unknown-linux-gnueabihf"
-fi
+#Set target triple
+flags="--target=arm-unknown-linux-gnueabihf"
 
 if [ "$1" != "-v" ]
 then

--- a/cross64
+++ b/cross64
@@ -8,15 +8,12 @@ export SYSROOT="$tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708ha
 #Include the cross copilation binaries
 export PATH="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin":$PATH
 
-if [ "$1" != "doc" ]
-then
-	#Set up our tools for anyting using these variables
-	export CC="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot"
-	export AR="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-ar"
+#Set up our tools for anyting using these variables
+export CC="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot"
+export AR="$tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-ar"
 
-	#Set target triple
-	flags="--target=arm-unknown-linux-gnueabihf"
-fi
+#Set target triple
+flags="--target=arm-unknown-linux-gnueabihf"
 
 if [ "$1" != "-v" ]
 then


### PR DESCRIPTION
I updated to use multirust.rs as said in #5. The build process doesn't need the `cross32` and `cross64` files anymore, but I kept them there so that somebody using the library could cross compile without the need for the variable exports. It would be perfect if those exports weren't needed, but I guess that for that we would need to port all WiringPi to Rust. It would be great, but it's too much work haha

Anyway, here is the updated version to use rustup.rs instead of multirust. I also added some Rust versions. From 1.9.0 onwards it's as simple as adding the actual version in the `env` section, and it will build for all the trains.

BTW, I saw you use your own script to upload docs. I wonder if using Travis-Cargo would be a better option (it also enables testing and coverage report).
