### PR TITLE
Stable Rust update

### DIFF
--- a/examples/flashing_lights.rs
+++ b/examples/flashing_lights.rs
@@ -1,7 +1,8 @@
 extern crate wiringpi;
 
 use wiringpi::pin::Value::{High, Low};
-use wiringpi::time::delay;
+use std::time::Duration;
+use std::thread;
 
 fn main() {
     //Setup WiringPi with its own pin numbering order
@@ -13,10 +14,10 @@ fn main() {
     loop {
         //Set pin 0 to high and wait one second
         pin.digital_write(High);
-        delay(1000);
+        thread::sleep(Duration::from_millis(1000));
 
         //Set pin 0 to low and wait one second
         pin.digital_write(Low);
-        delay(1000);
+        thread::sleep(Duration::from_millis(1000));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,42 +53,6 @@ macro_rules! require_root {
 
 mod bindings;
 
-pub mod time {
-    use bindings;
-    use std::time::Duration;
-
-    ///This causes program execution to pause for at least the provided
-    ///duration in milliseconds.
-    ///
-    ///Due to the multi-tasking nature of Linux it could be longer. Note that
-    ///the maximum delay is an unsigned 32-bit integer or approximately 49
-    ///days.
-    pub fn delay(duration: Duration) {
-        use libc;
-
-        let duration = (duration.as_secs() * 1000) as u32 + duration.subsec_nanos() / 1_000_000;
-        if duration <= 0 {
-            return;
-        }
-
-        unsafe {
-            bindings::delay(duration as libc::c_uint);
-        }
-    }
-
-    ///This causes program execution to pause for at least the provided number
-    ///of microseconds.
-    ///
-    ///Due to the multi-tasking nature of Linux it could be longer. Note that
-    ///the maximum delay is an unsigned 32-bit integer microseconds or
-    ///approximately 71 minutes.
-    pub fn delay_microseconds(microseconds: u32) {
-        unsafe {
-            bindings::delayMicroseconds(microseconds);
-        }
-    }
-}
-
 pub mod thread {
     use bindings;
     use libc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature="nightly", feature(duration))]
 #![doc(html_root_url = "http://ogeon.github.io/docs/rust-wiringpi/master/")]
 
 extern crate libc;
@@ -56,7 +55,6 @@ mod bindings;
 
 pub mod time {
     use bindings;
-    #[cfg(feature="nightly")]
     use std::time::Duration;
 
     ///This causes program execution to pause for at least the provided
@@ -65,30 +63,16 @@ pub mod time {
     ///Due to the multi-tasking nature of Linux it could be longer. Note that
     ///the maximum delay is an unsigned 32-bit integer or approximately 49
     ///days.
-    #[cfg(feature="nightly")]
     pub fn delay(duration: Duration) {
         use libc;
 
-        let duration = (duration.secs() * 1000) as u32 + duration.extra_nanos() / 1_000_000;
+        let duration = (duration.as_secs() * 1000) as u32 + duration.subsec_nanos() / 1_000_000;
         if duration <= 0 {
             return;
         }
 
         unsafe {
             bindings::delay(duration as libc::c_uint);
-        }
-    }
-
-    ///This causes program execution to pause for at least the provided number
-    ///of milliseconds.
-    ///
-    ///Due to the multi-tasking nature of Linux it could be longer. Note that
-    ///the maximum delay is an unsigned 32-bit integer or approximately 49
-    ///days.
-    #[cfg(not(feature="nightly"))]
-    pub fn delay(duration: u32) {
-        unsafe {
-            bindings::delay(duration);
         }
     }
 


### PR DESCRIPTION
I was also thinking that some functions might not make sense in Rust, such as delay(), since we have [`std::thread::sleep()`](https://doc.rust-lang.org/std/thread/fn.sleep.html). Also, some of the functions could be ported to Rust, I could do some work on it.

BTW, how do you feel by using rustfmt on the project to have the "common format"?

Oh, and this change should probably be implemented in a 0.2.x release, since it breaks the previous API. And seems we don't need the "nightly" feature.
