### PR TITLE
Added Rust 1.9.0 to Travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 os:
   - linux
 dist: trusty
+sudo: false
 
 # Build for all chains since Rust 1.8.0 (not available for prior versions)
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - RUST=nightly
   - RUST=beta
   - RUST=stable
+  - RUST=1.9.0
   - RUST=1.8.0
 
 # Install rust


### PR DESCRIPTION
Now the Travis build script builds for both Rust 1.8.0 and Rust 1.9.0.
