### PR TITLE
Update README - remove time module from sample codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ wiringpi = "0.2"
 extern crate wiringpi;
 
 use wiringpi::pin::Value::{High, Low};
-use wiringpi::time::delay;
+use std::{thread, time};
 
 fn main() {
     //Setup WiringPi with its own pin numbering order
@@ -28,14 +28,16 @@ fn main() {
     //Use WiringPi pin 0 as output
     let pin = pi.output_pin(0);
 
+    let interval = time::Duration::from_millis(1000);
+
     loop {
         //Set pin 0 to high and wait one second
         pin.digital_write(High);
-        delay(1000);
+        thread::sleep(interval);
 
         //Set pin 0 to low and wait one second
         pin.digital_write(Low);
-        delay(1000);
+        thread::sleep(interval);
     }
 }
 ```


### PR DESCRIPTION
We can't use wiringpi::time module because it was deleted.
So current sample code can't be compiled.

cf. https://github.com/Ogeon/rust-wiringpi/commit/8112364be366f97b40e91bf8ea9f5c2c4e6986ea