### PR TITLE
[proposal] development mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,8 @@ script:
   - ./cross64 "build -v --features orangepi --example flashing_lights"
   - ./cross64 "doc -v"
 
+  # development mode
+  - cargo build -v --features development
+  - cargo build -v --features development --example flashing_lights
+
 after_success: curl https://raw.githubusercontent.com/ogeon/travis-doc-upload/master/travis-doc-upload.sh | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT"
 [features]
 #Build patched version or wiringpi for Orange PI
 orangepi = []
+development = []
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -59,3 +59,23 @@ This can be enabled with the `orangepi` feature:
 verson = "0.2"
 features = ["orangepi"]
 ```
+
+##Development Mode
+
+In development mode, `rust-wiringpi` is compiled as a rust-native library excluding the original WiringPi.
+And binding functions are replaced by dummy functions that output simple logs to stdout.
+With this mode, you can build and debug your project on platforms that does not support WiringPi.
+
+```
+# build
+$ cargo build --features wiringpi/development
+
+# run
+$ cargo run --features wiringpi/development
+
+[wiringpi] `wiringPiSetup` called
+[wiringpi] `pinMode` called with: 0, 1
+[wiringpi] `digitalWrite` called with: 0, 1
+[wiringpi] `digitalWrite` called with: 0, 0
+...
+```

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,8 @@ const TARGET: &'static str = "wiringpi";
 const TARGET: &'static str = "wiringop";
 
 fn main() {
+    if cfg!(feature = "development") { return; }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     match Command::new("make").arg("-e").arg(TARGET).status() {
         Ok(status) if !status.success() => panic!("failed to build wiringPi C library (exit code {:?})", status.code()),

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -60,71 +60,94 @@ pub struct wiringPiNodeStruct {
 impl ::std::default::Default for wiringPiNodeStruct {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
-#[link(name = "wiringpi", kind = "static")]
-extern "C" {
-    pub static mut piModelNames: [*const ::libc::c_char; 16usize];
-    pub static mut piRevisionNames: [*const ::libc::c_char; 16usize];
-    pub static mut piMakerNames: [*const ::libc::c_char; 16usize];
-    pub static mut piMemorySize: [::libc::c_int; 8usize];
-    pub static mut wiringPiNodes: *mut wiringPiNodeStruct;
+
+use std::fmt::Write;
+
+macro_rules! binding_functions {
+    ( $( pub fn $name:ident ( $( $arg_name:ident: $arg_type:ty ),* ) -> $return_type:ty ; $return_value:expr ; )* ) => {
+        #[cfg(not(feature = "development"))]
+        #[link(name = "wiringpi", kind = "static")]
+        extern "C" {
+            $(
+                pub fn $name($($arg_name: $arg_type),*) -> $return_type;
+            )*
+        }
+
+        $(
+            #[cfg(feature = "development")]
+            pub fn $name($($arg_name: $arg_type),*) -> $return_type {
+                let mut args = String::new();
+
+                $(
+                    if args.is_empty() {
+                        write!(&mut args, "{:?}", $arg_name);
+                    } else {
+                        write!(&mut args, ", {:?}", $arg_name);
+                    }
+                )*
+
+                if args.is_empty() {
+                    println!("[wiringpi] `{}` called", stringify!($name));
+                } else {
+                    println!("[wiringpi] `{}` called with: {}", stringify!($name), args);
+                }
+
+                $return_value
+            }
+        )*
+    };
 }
-#[link(name = "wiringpi", kind = "static")]
-extern "C" {
-    pub fn wiringPiFailure(fatal: ::libc::c_int,
-                           message: *const ::libc::c_char, ...)
-     -> ::libc::c_int;
-    pub fn wiringPiFindNode(pin: ::libc::c_int) -> *mut wiringPiNodeStruct;
-    pub fn wiringPiNewNode(pinBase: ::libc::c_int, numPins: ::libc::c_int)
-     -> *mut wiringPiNodeStruct;
-    pub fn wiringPiSetup() -> ::libc::c_int;
-    pub fn wiringPiSetupSys() -> ::libc::c_int;
-    pub fn wiringPiSetupGpio() -> ::libc::c_int;
-    pub fn wiringPiSetupPhys() -> ::libc::c_int;
-    pub fn pinModeAlt(pin: ::libc::c_int, mode: ::libc::c_int);
-    pub fn pinMode(pin: ::libc::c_int, mode: ::libc::c_int);
-    pub fn pullUpDnControl(pin: ::libc::c_int, pud: ::libc::c_int);
-    pub fn digitalRead(pin: ::libc::c_int) -> ::libc::c_int;
-    pub fn digitalWrite(pin: ::libc::c_int, value: ::libc::c_int);
-    pub fn pwmWrite(pin: ::libc::c_int, value: ::libc::c_int);
-    pub fn analogRead(pin: ::libc::c_int) -> ::libc::c_int;
-    pub fn analogWrite(pin: ::libc::c_int, value: ::libc::c_int);
-    pub fn wiringPiSetupPiFace() -> ::libc::c_int;
-    pub fn wiringPiSetupPiFaceForGpioProg() -> ::libc::c_int;
-    pub fn piBoardRev() -> ::libc::c_int;
+
+binding_functions! {
+    pub fn wiringPiSetup() -> ::libc::c_int; 0;
+    pub fn wiringPiSetupSys() -> ::libc::c_int; 0;
+    pub fn wiringPiSetupGpio() -> ::libc::c_int; 0;
+    pub fn wiringPiSetupPhys() -> ::libc::c_int; 0;
+    pub fn pinModeAlt(pin: ::libc::c_int, mode: ::libc::c_int) -> (); ();
+    pub fn pinMode(pin: ::libc::c_int, mode: ::libc::c_int) -> (); ();
+    pub fn pullUpDnControl(pin: ::libc::c_int, pud: ::libc::c_int) -> (); ();
+    pub fn digitalRead(pin: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn digitalWrite(pin: ::libc::c_int, value: ::libc::c_int) -> (); ();
+    pub fn pwmWrite(pin: ::libc::c_int, value: ::libc::c_int) -> (); ();
+    pub fn analogRead(pin: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn analogWrite(pin: ::libc::c_int, value: ::libc::c_int) -> (); ();
+    pub fn wiringPiSetupPiFace() -> ::libc::c_int; 0;
+    pub fn wiringPiSetupPiFaceForGpioProg() -> ::libc::c_int; 0;
+    pub fn piBoardRev() -> ::libc::c_int; 0;
     pub fn piBoardId(model: *mut ::libc::c_int, rev: *mut ::libc::c_int,
                      mem: *mut ::libc::c_int, maker: *mut ::libc::c_int,
-                     overVolted: *mut ::libc::c_int);
-    pub fn wpiPinToGpio(wpiPin: ::libc::c_int) -> ::libc::c_int;
-    pub fn physPinToGpio(physPin: ::libc::c_int) -> ::libc::c_int;
-    pub fn setPadDrive(group: ::libc::c_int, value: ::libc::c_int);
-    pub fn getAlt(pin: ::libc::c_int) -> ::libc::c_int;
-    pub fn pwmToneWrite(pin: ::libc::c_int, freq: ::libc::c_int);
-    pub fn digitalWriteByte(value: ::libc::c_int);
-    pub fn digitalReadByte() -> ::libc::c_uint;
-    pub fn pwmSetMode(mode: ::libc::c_int);
-    pub fn pwmSetRange(range: ::libc::c_uint);
-    pub fn pwmSetClock(divisor: ::libc::c_int);
-    pub fn gpioClockSet(pin: ::libc::c_int, freq: ::libc::c_int);
+                     overVolted: *mut ::libc::c_int) -> (); ();
+    pub fn wpiPinToGpio(wpiPin: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn physPinToGpio(physPin: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn setPadDrive(group: ::libc::c_int, value: ::libc::c_int) -> (); ();
+    pub fn getAlt(pin: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn pwmToneWrite(pin: ::libc::c_int, freq: ::libc::c_int) -> (); ();
+    pub fn digitalWriteByte(value: ::libc::c_int) -> (); ();
+    pub fn digitalReadByte() -> ::libc::c_uint; 0;
+    pub fn pwmSetMode(mode: ::libc::c_int) -> (); ();
+    pub fn pwmSetRange(range: ::libc::c_uint) -> (); ();
+    pub fn pwmSetClock(divisor: ::libc::c_int) -> (); ();
+    pub fn gpioClockSet(pin: ::libc::c_int, freq: ::libc::c_int) -> (); ();
     pub fn waitForInterrupt(pin: ::libc::c_int, mS: ::libc::c_int)
-     -> ::libc::c_int;
+     -> ::libc::c_int; 0;
     pub fn wiringPiISR(pin: ::libc::c_int, mode: ::libc::c_int,
                        function: ::std::option::Option<extern "C" fn()>)
-     -> ::libc::c_int;
+     -> ::libc::c_int; 0;
     pub fn piThreadCreate(fn_:
                               ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                              *mut ::libc::c_void)
                                                         ->
                                                             *mut ::libc::c_void>)
-     -> ::libc::c_int;
-    pub fn piLock(key: ::libc::c_int);
-    pub fn piUnlock(key: ::libc::c_int);
-    pub fn piHiPri(pri: ::libc::c_int) -> ::libc::c_int;
-    pub fn delay(howLong: ::libc::c_uint);
-    pub fn delayMicroseconds(howLong: ::libc::c_uint);
-    pub fn millis() -> ::libc::c_uint;
-    pub fn micros() -> ::libc::c_uint;
+     -> ::libc::c_int; 0;
+    pub fn piLock(key: ::libc::c_int) -> (); ();
+    pub fn piUnlock(key: ::libc::c_int) -> (); ();
+    pub fn piHiPri(pri: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn delay(howLong: ::libc::c_uint) -> (); ();
+    pub fn delayMicroseconds(howLong: ::libc::c_uint) -> (); ();
+    pub fn millis() -> ::libc::c_uint; 0;
+    pub fn micros() -> ::libc::c_uint; 0;
     pub fn softPwmCreate(pin: ::libc::c_int, value: ::libc::c_int,
-                         range: ::libc::c_int) -> ::libc::c_int;
-    pub fn softPwmWrite(pin: ::libc::c_int, value: ::libc::c_int);
-    pub fn softPwmStop(pin: ::libc::c_int);
+                         range: ::libc::c_int) -> ::libc::c_int; 0;
+    pub fn softPwmWrite(pin: ::libc::c_int, value: ::libc::c_int) -> (); ();
+    pub fn softPwmStop(pin: ::libc::c_int) -> (); ();
 }


### PR DESCRIPTION
## Motivation

I usually write codes using Macbook. So I want to develop RPi project with Macbook.
But my project using `rust-wringpi` can't be compiled because original `wiringpi` doesn't support macOS. I think it's nice if it can at least be compiled.

## Proposal

New feature `development`.
It replace wiringpi bindings with dummy functions which only output simple logs.

In a cargo project using `rust-wiringpi`, we can switch mode.

- On RPi:

  ```
  cargo build
  cargo run
  ```

  These commands are same as current.

- On macbook:

  ```
  cargo build --features wiringpi/development
  cargo run --features wiringpi/development
  ```

  These commands

  - compile `rust-wiringpi` as rust native library
  - are available on macbook