### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This can be enabled with the `orangepi` feature:
 
 ```toml
 [dependencies.wiringpi]
-verson = "0.2"
+version = "0.2"
 features = ["orangepi"]
 ```
 


### PR DESCRIPTION
`verson` -> `version`