### PR TITLE
Add aarch64 as valid build target.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,10 @@ fn main() {
     // only build wiringpi/wiringop for arm/armv7 platforms
 
     let target = std::env::var("TARGET").unwrap();
-    if !(target.starts_with("arm-") || target.starts_with("armv7-")) {
+    if !(target.starts_with("arm-")
+        || target.starts_with("armv7-")
+        || target.starts_with("aarch64"))
+    {
         println!("cargo:rustc-cfg=feature=\"development\"");
         return;
     }

--- a/build.rs
+++ b/build.rs
@@ -22,14 +22,16 @@ fn main() {
         return;
     }
 
-    cc::Build::new()
-        .files(
-            glob::glob(&format!("{}/wiringPi/*.c", TARGET))
-                .unwrap()
-                .filter_map(|x| x.ok()),
-        )
-        .include(format!("{}/", TARGET))
-        .include(format!("{}/wiringPi/", TARGET))
-        .static_flag(true)
-        .compile("wiringpi");
+    let mut cc = cc::Build::new();
+    cc.files(
+        glob::glob(&format!("{}/wiringPi/*.c", TARGET))
+            .unwrap()
+            .filter_map(|x| x.ok()),
+    )
+    .include(format!("{}/", TARGET))
+    .include(format!("{}/wiringPi/", TARGET));
+    if target.starts_with("aarch64") {
+        cc.flag("-mabi=lp64").flag("-O2");
+    }
+    cc.static_flag(true).compile("wiringpi");
 }


### PR DESCRIPTION
I just added a check and used the build targets from the WiringPi project, now It also works on 64 bit raspberry OS versions